### PR TITLE
Add "system chat" (non-player chat message) option for auto thanks

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_12" project-jdk-name="12" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="18" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/SmileyPlayerTrader.iml
+++ b/SmileyPlayerTrader.iml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4" />

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/BugWarner.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/BugWarner.java
@@ -62,15 +62,13 @@ public class BugWarner {
                 }
             }
 
-            if (SmileyPlayerTrader.getInstance().getConfig().getBoolean("checkForBugs.disable", false) && disable) {
+            if (SmileyPlayerTrader.getInstance().getConfiguration().getCheckForBugsShouldDisable() && disable) {
                 SmileyPlayerTrader.getInstance().getLogger().severe("Disabling due to bugs...");
                 Bukkit.getPluginManager().disablePlugin(SmileyPlayerTrader.getInstance());
                 return true;
             }
 
             return false;
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
@@ -37,7 +37,7 @@ public class EventListener implements Listener {
         if(e.getHand() != EquipmentSlot.HAND)
             return;
 
-        if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("disableRightClickTrading", false))
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getDisableRightClickTrading())
             return;
         if(e.getRightClicked().hasMetadata("NPC")) // Citizens NPCs seem like players but they have different UUIDs and can't work.
             return;
@@ -153,7 +153,7 @@ public class EventListener implements Listener {
                         ex.printStackTrace();
                         SmileyPlayerTrader.getInstance().getLogger().severe("Something went wrong while attempting to give earnings to " + store.getName());
                     }
-                    if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("autoThanks", true) && store.isOnline()) {
+                    if(SmileyPlayerTrader.getInstance().getConfiguration().getAutoThanks() && store.isOnline()) {
                         store.getPlayer().chat(I18N.translate("&aThanks for your purchase, %0%", e.getWhoClicked().getName()));
                     }else{
                         e.getWhoClicked().sendMessage(I18N.translate("&aYou purchased an item from %0%", store.getName()));
@@ -210,8 +210,8 @@ public class EventListener implements Listener {
             }
         }
 
-        if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)
-            && SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.notifyUncollectedEarningsOnLogin", true)){
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()
+            && SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageNotifyUncollectedEarningsEnabled()){
             try(ResultSet set = SmileyPlayerTrader.getInstance().getStatementHandler().get(StatementHandler.StatementType.GET_UNCOLLECTED_EARNINGS, e.getPlayer().getUniqueId().toString())) {
                 if(set.next()){
                     if(set.getInt("uncollected_earnings") > 0){
@@ -234,11 +234,11 @@ public class EventListener implements Listener {
 
     @EventHandler
     public void onEntityTakeDamageByEntity(EntityDamageByEntityEvent e) {
-        if(SmileyPlayerTrader.getInstance().getConfig().getStringList("disabledWorlds").contains(e.getEntity().getWorld().getName())){
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getDisabledWorlds().contains(e.getEntity().getWorld().getName())){
             return;
         }
 
-        if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("autoCombatLock.enabled", true)) {
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getAutoCombatLockEnabled()) {
             if (e.getDamager() instanceof Player) {
                 SmileyPlayerTrader.getInstance().getPlayerConfig().lockPlayer((Player) e.getDamager());
             }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
@@ -153,11 +153,7 @@ public class EventListener implements Listener {
                         ex.printStackTrace();
                         SmileyPlayerTrader.getInstance().getLogger().severe("Something went wrong while attempting to give earnings to " + store.getName());
                     }
-                    if(SmileyPlayerTrader.getInstance().getConfiguration().getAutoThanks() && store.isOnline()) {
-                        store.getPlayer().chat(I18N.translate("&aThanks for your purchase, %0%", e.getWhoClicked().getName()));
-                    }else{
-                        e.getWhoClicked().sendMessage(I18N.translate("&aYou purchased an item from %0%", store.getName()));
-                    }
+                    MerchantUtil.thankPurchaser(store, (Player) e.getWhoClicked());
                     if(store.isOnline())
                         store.getPlayer().sendMessage(I18N.translate("&a%0% just purchased %1%!", e.getWhoClicked().getName(), mi.getSelectedRecipe().getResult().getType()));
                     try {

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/PlayerConfig.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/PlayerConfig.java
@@ -28,7 +28,7 @@ public class PlayerConfig {
         }
     }
 
-    private int LOCK_PERIOD = SmileyPlayerTrader.getInstance().getConfig().getInt("autoCombatLock.combatLockLength", 30) * 1000;
+    private int LOCK_PERIOD = SmileyPlayerTrader.getInstance().getConfiguration().getAutoCombatLockLength() * 1000;
     private Map<String, Config> playerConfigs = new HashMap<>();
     private Map<String, Long> playerCombatLock = new HashMap<>();
 
@@ -85,7 +85,7 @@ public class PlayerConfig {
     }
 
     public void lockPlayer(Player player){
-        if(!SmileyPlayerTrader.getInstance().getConfig().getBoolean("autoCombatLock.neverShowNotice", false)
+        if(!SmileyPlayerTrader.getInstance().getConfiguration().getAutoCombatLockNeverShowNotice()
                 && !isLocked(player) && getPlayer(player).combatNoticeToggle){
             player.sendMessage(I18N.translate("&7Player trading has been temporarily disabled while you are in combat. Use &f/spt releasecombatlock &7to re-enable trading early."));
 

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/SPTConfiguration.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/SPTConfiguration.java
@@ -1,7 +1,6 @@
 package io.github.mrcomputer1.smileyplayertrader;
 
 import io.github.mrcomputer1.smileyplayertrader.util.item.ItemUtil;
-import org.bukkit.Material;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.inventory.ItemStack;
 
@@ -23,9 +22,55 @@ public class SPTConfiguration {
         return this.config.getStringList("stockLocations");
     }
 
-    public boolean getAutoThanks(){
-        return this.config.getBoolean("autoThanks", true);
+    // Auto Thanks
+    public enum EnumAutoThanks{
+        PLAYER_CHAT("player_chat"),
+        SYSTEM_CHAT("system_chat"),
+        NONE("none");
+
+        private static final Map<String, EnumAutoThanks> autoThanksModes = new HashMap<>();
+
+        static{
+            for(EnumAutoThanks mode : values()){
+                autoThanksModes.put(mode.id.toLowerCase(), mode);
+            }
+        }
+
+        public static EnumAutoThanks getById(String id){
+            if(id == null)
+                return EnumAutoThanks.SYSTEM_CHAT;
+            EnumAutoThanks mode = autoThanksModes.get(id.toLowerCase());
+            return mode == null ? EnumAutoThanks.SYSTEM_CHAT : mode;
+        }
+
+        private final String id;
+
+        EnumAutoThanks(String id){
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
     }
+
+    public EnumAutoThanks getAutoThanksMode(){
+        // Legacy config property support
+        if(this.config.isBoolean("autoThanks"))
+            return this.config.getBoolean("autoThanks", true) ? EnumAutoThanks.SYSTEM_CHAT : EnumAutoThanks.NONE;
+
+        return EnumAutoThanks.getById(this.config.getString("autoThanks.mode", EnumAutoThanks.SYSTEM_CHAT.getId()));
+    }
+
+    public String getAutoThanksMessage(){
+        String message = this.config.getString("autoThanks.message", "default");
+        //noinspection ConstantConditions
+        if(message.equalsIgnoreCase("default"))
+            return null;
+        else
+            return message;
+    }
+    // End Auto Thanks
 
     public String getCurrentLanguage(){
         return this.config.getString("currentLanguage", "en_us");

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/SPTConfiguration.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/SPTConfiguration.java
@@ -1,0 +1,228 @@
+package io.github.mrcomputer1.smileyplayertrader;
+
+import io.github.mrcomputer1.smileyplayertrader.util.item.ItemUtil;
+import org.bukkit.Material;
+import org.bukkit.configuration.Configuration;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+
+public class SPTConfiguration {
+
+    private final Configuration config;
+
+    public SPTConfiguration(Configuration config){
+        this.config = config;
+    }
+
+    public List<String> getDisabledWorlds(){
+        return this.config.getStringList("disabledWorlds");
+    }
+
+    public List<String> getStockLocations(){
+        return this.config.getStringList("stockLocations");
+    }
+
+    public boolean getAutoThanks(){
+        return this.config.getBoolean("autoThanks", true);
+    }
+
+    public String getCurrentLanguage(){
+        return this.config.getString("currentLanguage", "en_us");
+    }
+
+    // Start Database
+    public String getDatabaseType(){
+        return this.config.getString("database.type", "sqlite");
+    }
+
+    public String getDatabaseFile(){
+        return this.config.getString("database.file", "database.db");
+    }
+
+    public String getDatabasePrefix(){
+        return this.config.getString("database.prefix", "spt");
+    }
+
+    public String getDatabaseHost(){
+        return this.config.getString("database.host");
+    }
+
+    public int getDatabasePort(){
+        return this.config.getInt("database.port", 3306);
+    }
+
+    public String getDatabaseName(){
+        return this.config.getString("database.name");
+    }
+
+    public String getDatabaseUsername(){
+        return this.config.getString("database.username");
+    }
+
+    public String getDatabasePassword(){
+        return this.config.getString("database.password");
+    }
+    // End Database
+
+    public boolean getCheckForUpdatesEnabled(){
+        return this.config.getBoolean("checkForUpdates", true);
+    }
+
+    // Start Bug Warner
+    public boolean getCheckForBugsEnabled(){
+        return this.config.getBoolean("checkForBugs.check", false);
+    }
+
+    public boolean getCheckForBugsShouldDisable(){
+        return this.config.getBoolean("checkForBugs.disable", false);
+    }
+    // End Bug Warner
+
+    public boolean getUseGuiManager(){
+        return this.config.getBoolean("useGuiManager", true);
+    }
+
+    public boolean getDisableRightClickTrading(){
+        return this.config.getBoolean("disableRightClickTrading", false);
+    }
+
+    // Start Item Storage
+    public boolean getItemStorageEnabled(){
+        return this.config.getBoolean("itemStorage.enable", false);
+    }
+
+    public int getItemStorageProductStorageLimit(){
+        return this.config.getInt("itemStorage.productStorageLimit", -1);
+    }
+
+    public boolean getItemStorageNotifyUncollectedEarningsEnabled(){
+        return this.config.getBoolean("itemStorage.notifyUncollectedEarningsOnLogin", true);
+    }
+    // End Item Storage
+
+    // Start Out of Stock Behaviour
+    public enum EnumOutOfStockBehaviour{
+        SHOW_BY_DEFAULT("showByDefault"),
+        HIDE_BY_DEFAULT("hideByDefault"),
+        SHOW("show"),
+        HIDE("hide");
+
+        private static final Map<String, EnumOutOfStockBehaviour> behaviours = new HashMap<>();
+
+        static {
+            for(EnumOutOfStockBehaviour behaviour : values()){
+                behaviours.put(behaviour.id.toLowerCase(), behaviour);
+            }
+        }
+
+        public static EnumOutOfStockBehaviour getById(String id){
+            if(id == null)
+                return EnumOutOfStockBehaviour.SHOW_BY_DEFAULT;
+            EnumOutOfStockBehaviour behaviour = behaviours.get(id.toLowerCase());
+            return behaviour == null ? EnumOutOfStockBehaviour.SHOW_BY_DEFAULT : behaviour;
+        }
+
+        private final String id;
+
+        EnumOutOfStockBehaviour(String id){
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+    }
+
+    public EnumOutOfStockBehaviour getOutOfStockBehaviour(){
+        return EnumOutOfStockBehaviour.getById(this.config.getString("outOfStockBehaviour", EnumOutOfStockBehaviour.SHOW_BY_DEFAULT.getId()));
+    }
+    // End Out of Stock Behaviour
+
+    // Start Auto Combat Lock
+    public boolean getAutoCombatLockEnabled(){
+        return this.config.getBoolean("autoCombatLock.enabled", true);
+    }
+
+    public int getAutoCombatLockLength(){
+        return this.config.getInt("autoCombatLock.combatLockLength", 30);
+    }
+
+    public boolean getAutoCombatLockNeverShowNotice(){
+        return this.config.getBoolean("autoCombatLock.neverShowNotice", false);
+    }
+    // End Auto Combat Lock
+
+    public List<ItemStack> getPriceQuickSelection(){
+        List<?> priceQuickSelection = SmileyPlayerTrader.getInstance().getConfig().getList("priceQuickSelection", new ArrayList<>());
+        List<ItemStack> stacks = new ArrayList<>();
+        //noinspection ConstantConditions
+        for (Object itemObject : priceQuickSelection) {
+            try {
+                //noinspection unchecked
+                LinkedHashMap<String, Object> item = (LinkedHashMap<String, Object>) itemObject;
+
+                ItemStack stack = ItemUtil.buildConfigurationItem(item);
+                if (stack != null)
+                    stacks.add(stack);
+            }catch (ClassCastException ex){
+                SmileyPlayerTrader.getInstance().getLogger().severe("Failed to parse price quick selection item.");
+            }
+        }
+        return stacks;
+    }
+
+    // Start Price Selector Menu
+    public boolean getPriceSelectorMenuAutomaticAddVanilla(){
+        return this.config.getBoolean("priceSelectorMenu.automaticAdd.vanilla", true);
+    }
+
+    public List<String> getPriceSelectorMenuHiddenItems(){
+        return this.config.getStringList("priceSelectorMenu.hiddenItems");
+    }
+
+    public List<ItemStack> getPriceSelectorMenuExtraItems(){
+        List<?> extraItems = SmileyPlayerTrader.getInstance().getConfig().getList("priceSelectorMenu.extraItems", new ArrayList<>());
+        List<ItemStack> stacks = new ArrayList<>();
+        //noinspection ConstantConditions
+        for (Object itemObject : extraItems) {
+            try {
+                //noinspection unchecked
+                LinkedHashMap<String, Object> item = (LinkedHashMap<String, Object>) itemObject;
+
+                ItemStack stack = ItemUtil.buildConfigurationItem(item);
+                if (stack != null)
+                    stacks.add(stack);
+            }catch (ClassCastException ex){
+                SmileyPlayerTrader.getInstance().getLogger().severe("Failed to parse price selector menu extra item.");
+            }
+        }
+        return stacks;
+    }
+
+    public List<ItemStack> getPriceSelectorMenuFeaturedItems(){
+        List<?> featuredItems = SmileyPlayerTrader.getInstance().getConfig().getList("priceSelectorMenu.featuredItems", new ArrayList<>());
+        List<ItemStack> stacks = new ArrayList<>();
+        //noinspection ConstantConditions
+        for (Object itemObject : featuredItems) {
+            try {
+                //noinspection unchecked
+                LinkedHashMap<String, Object> item = (LinkedHashMap<String, Object>) itemObject;
+
+                ItemStack stack = ItemUtil.buildConfigurationItem(item);
+                if (stack != null)
+                    stacks.add(stack);
+            }catch (ClassCastException ex){
+                SmileyPlayerTrader.getInstance().getLogger().severe("Failed to parse price selector menu featured item.");
+            }
+        }
+        return stacks;
+    }
+    // End Price Selector Menu
+
+    public boolean getDebugSelfTrading(){
+        return this.config.getBoolean("debugSelfTrading", false);
+    }
+
+}

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/SmileyPlayerTrader.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/SmileyPlayerTrader.java
@@ -29,6 +29,7 @@ public class SmileyPlayerTrader extends JavaPlugin {
     private UpdateChecker updateChecker = null;
     private BugWarner bugWarner = null;
     private VersionSupport versionSupport = null;
+    private SPTConfiguration configuration = null;
 
     private Metrics metrics = null;
 
@@ -36,6 +37,7 @@ public class SmileyPlayerTrader extends JavaPlugin {
     public void onEnable() {
         // Configuration
         saveDefaultConfig();
+        this.configuration = new SPTConfiguration(getConfig());
 
         // bStats
         if(!getDescription().getVersion().contains("-SNAPSHOT")) { // Disable bStats on development versions.
@@ -44,7 +46,7 @@ public class SmileyPlayerTrader extends JavaPlugin {
             this.metrics.addCustomChart(new Metrics.SimplePie("database_system", new Callable<String>() {
                 @Override
                 public String call() {
-                    switch(getConfig().getString("database.type", "sqlite")){
+                    switch(getConfiguration().getDatabaseType()){
                         case "sqlite":
                             return "SQLite";
                         case "mysql":
@@ -63,13 +65,13 @@ public class SmileyPlayerTrader extends JavaPlugin {
         this.i18n.updateLanguage();
 
         // Update Checker
-        if(getConfig().getBoolean("checkForUpdates", true)){
+        if(getConfiguration().getCheckForUpdatesEnabled()){
             this.updateChecker = new UpdateChecker();
             this.updateChecker.checkForUpdates();
         }
 
         // Bug Warner
-        if(getConfig().getBoolean("checkForBugs.check", false)){
+        if(getConfiguration().getCheckForBugsEnabled()){
             this.bugWarner = new BugWarner();
             boolean b = this.bugWarner.checkForBugs();
             if(b)
@@ -88,8 +90,8 @@ public class SmileyPlayerTrader extends JavaPlugin {
 
         // Database
         boolean shouldCreateTables = true;
-        if(this.getConfig().getString("database.type", "sqlite").equals("sqlite")){
-            if(new File(this.getDataFolder(), this.getConfig().getString("database.file", "database.db")).exists()){
+        if(this.getConfiguration().getDatabaseType().equals("sqlite")){
+            if(new File(this.getDataFolder(), this.getConfiguration().getDatabaseFile()).exists()){
                 shouldCreateTables = false;
             }
         }
@@ -115,7 +117,7 @@ public class SmileyPlayerTrader extends JavaPlugin {
 
         // GUIs
         Bukkit.getPluginManager().registerEvents(new EventListener(), this);
-        if(getConfig().getBoolean("useGuiManager", true)){
+        if(getConfiguration().getUseGuiManager()){
             Bukkit.getPluginManager().registerEvents(new GUIEventListener(), this);
         }
     }
@@ -153,5 +155,9 @@ public class SmileyPlayerTrader extends JavaPlugin {
 
     public PlayerConfig getPlayerConfig(){
         return this.playerConfig;
+    }
+
+    public SPTConfiguration getConfiguration() {
+        return this.configuration;
     }
 }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/AddCommand.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/AddCommand.java
@@ -1,5 +1,6 @@
 package io.github.mrcomputer1.smileyplayertrader.command;
 
+import io.github.mrcomputer1.smileyplayertrader.SPTConfiguration;
 import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
 import io.github.mrcomputer1.smileyplayertrader.util.I18N;
 import io.github.mrcomputer1.smileyplayertrader.util.database.statements.StatementHandler;
@@ -26,16 +27,15 @@ public class AddCommand implements ICommand {
             target = (Player)sender;
         }
 
-        String outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfig().getString("outOfStockBehaviour", "showByDefault");
-        boolean hideOnOutOfStock = false;
-        //noinspection ConstantConditions
-        switch (outOfStockBehaviour.toLowerCase()){
-            case "hidebydefault":
-            case "hide":
+        SPTConfiguration.EnumOutOfStockBehaviour outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfiguration().getOutOfStockBehaviour();
+        boolean hideOnOutOfStock;
+        switch (outOfStockBehaviour){
+            case HIDE_BY_DEFAULT:
+            case HIDE:
                 hideOnOutOfStock = true;
                 break;
-            case "showbydefault":
-            case "show":
+            case SHOW_BY_DEFAULT:
+            case SHOW:
             default:
                 hideOnOutOfStock = false;
                 break;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/CollectCommand.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/CollectCommand.java
@@ -23,7 +23,7 @@ public class CollectCommand implements ICommand{
             return;
         }
 
-        if(!SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)){
+        if(!SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()){
             sender.sendMessage(I18N.translate("&cItem storage is not enabled."));
             return;
         }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/CommandSmileyPlayerTrader.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/CommandSmileyPlayerTrader.java
@@ -47,7 +47,7 @@ public class CommandSmileyPlayerTrader implements TabExecutor {
             return false;
 
         if(args.length == 0){
-            if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("useGuiManager", true)) {
+            if(SmileyPlayerTrader.getInstance().getConfiguration().getUseGuiManager()) {
                 if(!(sender instanceof Player)){
                     sender.sendMessage(I18N.translate("&cYou must be running this command from a player."));
                     return true;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/DepositCommand.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/DepositCommand.java
@@ -21,7 +21,7 @@ public class DepositCommand implements ICommand{
             return;
         }
 
-        if(!SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)){
+        if(!SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()){
             sender.sendMessage(I18N.translate("&cItem storage is not enabled."));
             return;
         }
@@ -65,7 +65,7 @@ public class DepositCommand implements ICommand{
                 if(hand.isSimilar(product)){
                     int count = hand.getAmount();
 
-                    int limit = SmileyPlayerTrader.getInstance().getConfig().getInt("itemStorage.productStorageLimit", -1);
+                    int limit = SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageProductStorageLimit();
                     if(limit != -1 && set.getInt("stored_product") + count > limit){
                         sender.sendMessage(I18N.translate("&cYou cannot store more than %0% of a product.", limit));
                         return;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/OpenGUIForCommand.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/OpenGUIForCommand.java
@@ -16,7 +16,7 @@ public class OpenGUIForCommand implements ICommand{
             return;
         }
 
-        if(!SmileyPlayerTrader.getInstance().getConfig().getBoolean("useGuiManager", true)){
+        if(!SmileyPlayerTrader.getInstance().getConfiguration().getUseGuiManager()){
             sender.sendMessage(I18N.translate("&cGUI functionality is disabled, this command has no effect."));
             return;
         }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/WithdrawCommand.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/command/WithdrawCommand.java
@@ -22,7 +22,7 @@ public class WithdrawCommand implements ICommand{
             return;
         }
 
-        if(!SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)){
+        if(!SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()){
             sender.sendMessage(I18N.translate("&cItem storage is not enabled."));
             return;
         }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIItemSelector.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIItemSelector.java
@@ -80,12 +80,12 @@ public class GUIItemSelector extends AbstractGUI {
         this.getInventory().setItem((5 * 9) + 8, NEXT_BTN.clone());
         this.getInventory().setItem((5 * 9) + 4, CANCEL_BTN.clone());
 
-        List<String> hiddenItems = (List<String>) SmileyPlayerTrader.getInstance().getConfig().getList("priceSelectorMenu.hiddenItems", new ArrayList<>());
+        List<String> hiddenItems = SmileyPlayerTrader.getInstance().getConfiguration().getPriceSelectorMenuHiddenItems();
         if(itemStacks == null){
             itemStacks = new ArrayList<>();
 
             if(filter != EnumItemSelectorFilter.FEATURED) {
-                if (SmileyPlayerTrader.getInstance().getConfig().getBoolean("priceSelectorMenu.automaticAdd.vanilla", true)) {
+                if (SmileyPlayerTrader.getInstance().getConfiguration().getPriceSelectorMenuAutomaticAddVanilla()) {
                     // Vanilla Items
                     for (Material m : Material.values()) {
                         if (ItemUtil.isHiddenItem(hiddenItems, m)) {
@@ -103,9 +103,9 @@ public class GUIItemSelector extends AbstractGUI {
                 }
 
                 // Extra Items
-                List<LinkedHashMap<String, Object>> extraItems = (List<LinkedHashMap<String, Object>>) SmileyPlayerTrader.getInstance().getConfig().getList("priceSelectorMenu.extraItems", new ArrayList<>());
-                for (LinkedHashMap<String, Object> item : extraItems) {
-                    ItemStack is = prepareItemStack(ItemUtil.buildConfigurationItem(item));
+                List<ItemStack> extraItems = SmileyPlayerTrader.getInstance().getConfiguration().getPriceSelectorMenuExtraItems();
+                for (ItemStack item : extraItems) {
+                    ItemStack is = prepareItemStack(item);
 
                     if (is == null)
                         continue;
@@ -129,9 +129,9 @@ public class GUIItemSelector extends AbstractGUI {
                 // End Integration Filters
             }else{
                 // Featured Items
-                List<LinkedHashMap<String, Object>> featuredItems = (List<LinkedHashMap<String, Object>>) SmileyPlayerTrader.getInstance().getConfig().getList("priceSelectorMenu.featuredItems", new ArrayList<>());
-                for(LinkedHashMap<String, Object> item : featuredItems){
-                    ItemStack is = prepareItemStack(ItemUtil.buildConfigurationItem(item));
+                List<ItemStack> featuredItems = SmileyPlayerTrader.getInstance().getConfiguration().getPriceSelectorMenuFeaturedItems();
+                for(ItemStack item : featuredItems){
+                    ItemStack is = prepareItemStack(item);
 
                     if(is == null)
                         continue;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIItemStorage.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIItemStorage.java
@@ -111,7 +111,7 @@ public class GUIItemStorage extends AbstractGUI{
             if(clicked.isSimilar(product)) {
                 int count = clicked.getAmount();
 
-                int limit = SmileyPlayerTrader.getInstance().getConfig().getInt("itemStorage.productStorageLimit", -1);
+                int limit = SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageProductStorageLimit();
                 if (limit != -1 && this.storedProduct + count > limit) {
                     player.sendMessage(I18N.translate("&cYou cannot store more than %0% of a product.", limit));
                     return true;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIListItems.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIListItems.java
@@ -62,7 +62,7 @@ public class GUIListItems extends AbstractGUI {
         GUIUtil.fillStartAndEnd(this.getInventory(), 3, BORDER);
         GUIUtil.fillStartAndEnd(this.getInventory(), 4, BORDER);
 
-        if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)){
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()){
             this.getInventory().setItem(5 * 9, COLLECT_EARNINGS_BTN);
         }else{
             this.getInventory().setItem(5 * 9, MENU_BAR);
@@ -165,7 +165,7 @@ public class GUIListItems extends AbstractGUI {
                 }else if(e.getClick() == ClickType.SHIFT_LEFT || e.getClick() == ClickType.SHIFT_RIGHT){
 
                     // Shift Click - Deposit/Withdraw
-                    if(!SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false))
+                    if(!SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled())
                         return true;
 
                     try(ResultSet set = SmileyPlayerTrader.getInstance().getStatementHandler().get(StatementHandler.StatementType.GET_PRODUCT_BY_ID, id)) {
@@ -227,7 +227,7 @@ public class GUIListItems extends AbstractGUI {
                     lore.add(I18N.translate("&bRight Click to &lEnable/Show"));
                 }
 
-                if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)){
+                if(SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()){
                     lore.add(I18N.translate("&bShift Click to &lManage Stored Items"));
                 }
 
@@ -238,7 +238,7 @@ public class GUIListItems extends AbstractGUI {
                 stacks.add(is);
             }
 
-            if(SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false)){
+            if(SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled()){
                 try(ResultSet set2 = SmileyPlayerTrader.getInstance().getStatementHandler().get(StatementHandler.StatementType.GET_UNCOLLECTED_EARNINGS, this.player.getUniqueId().toString())) {
                     if (set2.next()) {
                         if (set2.getInt("uncollected_earnings") > 0) {

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIProduct.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUIProduct.java
@@ -1,5 +1,6 @@
 package io.github.mrcomputer1.smileyplayertrader.gui;
 
+import io.github.mrcomputer1.smileyplayertrader.SPTConfiguration;
 import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
 import io.github.mrcomputer1.smileyplayertrader.util.GUIUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.I18N;
@@ -65,15 +66,14 @@ public class GUIProduct extends AbstractGUI {
         this.getInventory().setItem((1 * 9) + 4, INSERT_PRODUCT_LBL.clone());
         GUIUtil.drawLine(this.getInventory(), (1 * 9) + 5, 3, BORDER);
 
-        String outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfig().getString("outOfStockBehaviour", "showByDefault");
-        //noinspection ConstantConditions
-        switch (outOfStockBehaviour.toLowerCase()){
-            case "show":
-            case "hide":
+        SPTConfiguration.EnumOutOfStockBehaviour outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfiguration().getOutOfStockBehaviour();
+        switch (outOfStockBehaviour){
+            case SHOW:
+            case HIDE:
                 this.getInventory().setItem((1 * 9) + 8, BORDER.clone());
                 break;
-            case "showbydefault":
-            case "hidebydefault":
+            case SHOW_BY_DEFAULT:
+            case HIDE_BY_DEFAULT:
             default:
                 updateHideOnOutOfStockButton();
         }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUISetCost.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/GUISetCost.java
@@ -72,14 +72,15 @@ public class GUISetCost extends AbstractGUI {
         GUIUtil.fillRow(this.getInventory(), 3, BORDER);
 
         // Quick Selection Row
-        List<LinkedHashMap<String, Object>> priceQuickSelection = (List<LinkedHashMap<String, Object>>) SmileyPlayerTrader.getInstance().getConfig().getList("priceQuickSelection", new ArrayList<>());
+        List<ItemStack> priceQuickSelectionStacks = SmileyPlayerTrader.getInstance().getConfiguration().getPriceQuickSelection();
         List<ItemStack> stacks = new ArrayList<>();
         int stackCount = 0;
-        for(LinkedHashMap<String, Object> item : priceQuickSelection){
-            if(stackCount++ >= 6){ // ensure only 6 items are on the quick selection row
+        for(ItemStack item : priceQuickSelectionStacks){
+            if (stackCount++ >= 6) { // ensure only 6 items are on the quick selection row
                 SmileyPlayerTrader.getInstance().getLogger().warning("You have too many quick selection items.");
                 break;
             }
+
             ItemStack stack = createQuickSelectionRowItem(item);
             if(stack != null)
                 stacks.add(stack);
@@ -149,9 +150,7 @@ public class GUISetCost extends AbstractGUI {
         }
     }
 
-    private ItemStack createQuickSelectionRowItem(LinkedHashMap<String, Object> item){
-        ItemStack is = ItemUtil.buildConfigurationItem(item);
-
+    private ItemStack createQuickSelectionRowItem(ItemStack is){
         if(is == null)
             return null;
 

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/ProductGUIState.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/gui/ProductGUIState.java
@@ -1,5 +1,6 @@
 package io.github.mrcomputer1.smileyplayertrader.gui;
 
+import io.github.mrcomputer1.smileyplayertrader.SPTConfiguration;
 import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -64,15 +65,14 @@ public class ProductGUIState {
         this.id = -1L;
         this.isEditing = false;
 
-        String outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfig().getString("outOfStockBehaviour", "showByDefault");
-        //noinspection ConstantConditions
-        switch (outOfStockBehaviour.toLowerCase()){
-            case "hidebydefault":
-            case "hide":
+        SPTConfiguration.EnumOutOfStockBehaviour outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfiguration().getOutOfStockBehaviour();
+        switch (outOfStockBehaviour){
+            case HIDE_BY_DEFAULT:
+            case HIDE:
                 this.hideOnOutOfStock = true;
                 break;
-            case "showbydefault":
-            case "show":
+            case SHOW_BY_DEFAULT:
+            case SHOW:
             default:
                 this.hideOnOutOfStock = false;
                 break;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/I18N.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/I18N.java
@@ -12,7 +12,7 @@ public class I18N {
     private static String[] languages = {"en_us"};
 
     public void loadLanguages(){
-        String lang = SmileyPlayerTrader.getInstance().getConfig().getString("currentLanguage", "en_us");
+        String lang = SmileyPlayerTrader.getInstance().getConfiguration().getCurrentLanguage();
         File langFolder = new File(SmileyPlayerTrader.getInstance().getDataFolder(), "languages");
         JsonParser parser = new JsonParser();
         try {
@@ -39,7 +39,7 @@ public class I18N {
 
     public void updateLanguage(){
         try {
-            String lang = SmileyPlayerTrader.getInstance().getConfig().getString("currentLanguage", "en_us");
+            String lang = SmileyPlayerTrader.getInstance().getConfiguration().getCurrentLanguage();
             InputStream resource = SmileyPlayerTrader.getInstance().getResource("languages/" + lang + ".json");
             if (resource == null) {
                 return;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/database/AbstractDatabase.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/database/AbstractDatabase.java
@@ -19,13 +19,13 @@ public abstract class AbstractDatabase {
     public abstract void close();
 
     public String getDatabasePrefix(){
-        return SmileyPlayerTrader.getInstance().getConfig().getString("database.prefix", "spt");
+        return SmileyPlayerTrader.getInstance().getConfiguration().getDatabasePrefix();
     }
 
     public StatementHandler getNewStatementHandler(){
-        if(SmileyPlayerTrader.getInstance().getConfig().getString("database.type", "sqlite").equals("sqlite")){
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseType().equals("sqlite")){
             return new SQLiteStatementHandler((SQLiteDatabase)this);
-        }else if(SmileyPlayerTrader.getInstance().getConfig().getString("database.type").equals("mysql")){
+        }else if(SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseType().equals("mysql")){
             return new MySQLStatementHandler((MySQLDatabase)this);
         }else return null;
     }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/database/DatabaseUtil.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/database/DatabaseUtil.java
@@ -9,9 +9,9 @@ public class DatabaseUtil {
 
     public static AbstractDatabase loadDatabase(){
         AbstractDatabase db;
-        switch(SmileyPlayerTrader.getInstance().getConfig().getString("database.type", "sqlite")){
+        switch(SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseType()){
             case "sqlite":
-                db = new SQLiteDatabase(new File(SmileyPlayerTrader.getInstance().getDataFolder(), SmileyPlayerTrader.getInstance().getConfig().getString("database.file", "database.db")));
+                db = new SQLiteDatabase(new File(SmileyPlayerTrader.getInstance().getDataFolder(), SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseFile()));
                 break;
             case "mysql":
                 if(!SmileyPlayerTrader.getInstance().getConfig().contains("database.host")
@@ -23,11 +23,11 @@ public class DatabaseUtil {
                     return null;
                 }else{
                     db = new MySQLDatabase(
-                            SmileyPlayerTrader.getInstance().getConfig().getString("database.host"),
-                            SmileyPlayerTrader.getInstance().getConfig().getInt("database.port", 3306),
-                            SmileyPlayerTrader.getInstance().getConfig().getString("database.name"),
-                            SmileyPlayerTrader.getInstance().getConfig().getString("database.username"),
-                            SmileyPlayerTrader.getInstance().getConfig().getString("database.password")
+                            SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseHost(),
+                            SmileyPlayerTrader.getInstance().getConfiguration().getDatabasePort(),
+                            SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseName(),
+                            SmileyPlayerTrader.getInstance().getConfiguration().getDatabaseUsername(),
+                            SmileyPlayerTrader.getInstance().getConfiguration().getDatabasePassword()
                     );
                 }
                 break;

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/item/stocklocations/ItemStorageStockLocation.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/item/stocklocations/ItemStorageStockLocation.java
@@ -43,7 +43,7 @@ public class ItemStorageStockLocation implements IStockLocation{
 
     @Override
     public boolean isAvailable(OfflinePlayer player) {
-        return SmileyPlayerTrader.getInstance().getConfig().getBoolean("itemStorage.enable", false);
+        return SmileyPlayerTrader.getInstance().getConfiguration().getItemStorageEnabled();
     }
 
 }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/item/stocklocations/StockLocations.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/item/stocklocations/StockLocations.java
@@ -25,7 +25,7 @@ public class StockLocations {
     }
 
     public static List<IStockLocation> getActiveStockLocations(){
-        List<String> locations = SmileyPlayerTrader.getInstance().getConfig().getStringList("stockLocations");
+        List<String> locations = SmileyPlayerTrader.getInstance().getConfiguration().getStockLocations();
 
         ArrayList<IStockLocation> stockLocations = new ArrayList<>();
 

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
@@ -1,5 +1,6 @@
 package io.github.mrcomputer1.smileyplayertrader.util.merchant;
 
+import io.github.mrcomputer1.smileyplayertrader.SPTConfiguration;
 import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
 import io.github.mrcomputer1.smileyplayertrader.util.I18N;
 import io.github.mrcomputer1.smileyplayertrader.util.VaultUtil;
@@ -47,13 +48,13 @@ public class MerchantUtil {
             return;
         }
 
-        if(SmileyPlayerTrader.getInstance().getConfig().getStringList("disabledWorlds").contains(player.getWorld().getName())){
+        if(SmileyPlayerTrader.getInstance().getConfiguration().getDisabledWorlds().contains(player.getWorld().getName())){
             if(unsuccessfulFeedback)
                 player.sendMessage(I18N.translate("&cYou cannot trade in this world."));
             return;
         }
 
-        if(player.getUniqueId().equals(store.getUniqueId()) && !SmileyPlayerTrader.getInstance().getConfig().getBoolean("debugSelfTrading", false)){
+        if(player.getUniqueId().equals(store.getUniqueId()) && !SmileyPlayerTrader.getInstance().getConfiguration().getDebugSelfTrading()){
             if(unsuccessfulFeedback)
                 player.sendMessage(I18N.translate("&cYou cannot trade with yourself."));
             return;
@@ -165,10 +166,10 @@ public class MerchantUtil {
                 }
 
                 if(!ItemUtil.doesPlayerHaveItem(merchant, is, set.getLong("id"))){
-                    String outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfig().getString("outOfStockBehaviour", "showByDefault");
-                    if(outOfStockBehaviour.equalsIgnoreCase("hide"))
+                    SPTConfiguration.EnumOutOfStockBehaviour outOfStockBehaviour = SmileyPlayerTrader.getInstance().getConfiguration().getOutOfStockBehaviour();
+                    if(outOfStockBehaviour == SPTConfiguration.EnumOutOfStockBehaviour.HIDE)
                         continue;
-                    if(!outOfStockBehaviour.equalsIgnoreCase("show") && set.getBoolean("hide_on_out_of_stock"))
+                    if(outOfStockBehaviour != SPTConfiguration.EnumOutOfStockBehaviour.SHOW && set.getBoolean("hide_on_out_of_stock"))
                         continue;
                     mr.setUses(Integer.MAX_VALUE);
                 }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
@@ -4,12 +4,12 @@ import io.github.mrcomputer1.smileyplayertrader.SPTConfiguration;
 import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
 import io.github.mrcomputer1.smileyplayertrader.util.I18N;
 import io.github.mrcomputer1.smileyplayertrader.util.VaultUtil;
-import io.github.mrcomputer1.smileyplayertrader.util.item.ItemUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.database.statements.StatementHandler;
-import io.github.mrcomputer1.smileyplayertrader.util.item.stocklocations.IStockLocation;
+import io.github.mrcomputer1.smileyplayertrader.util.item.ItemUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.item.stocklocations.StockLocations;
 import io.github.mrcomputer1.smileyplayertrader.versions.VersionSupport;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -39,6 +39,48 @@ public class MerchantUtil {
     public static void openPreviewMerchant(Player player){
         Merchant merchant = MerchantUtil.buildMerchant(player, new IdentityHashMap<>(), true);
         player.openMerchant(merchant, true);
+    }
+
+    public static void thankPurchaser(OfflinePlayer merchant, Player customer){
+        String message = SmileyPlayerTrader.getInstance().getConfiguration().getAutoThanksMessage();
+        switch(SmileyPlayerTrader.getInstance().getConfiguration().getAutoThanksMode()){
+            case NONE:
+                customer.sendMessage(I18N.translate("&aYou purchased an item from %0%", merchant.getName()));
+                return;
+            case PLAYER_CHAT:
+                if(!merchant.isOnline()) {
+                    customer.sendMessage(I18N.translate("&aYou purchased an item from %0%", merchant.getName()));
+                    return;
+                }
+
+                // This requireNonNull should never catch a null.
+                Player onlineMerchant = Objects.requireNonNull(merchant.getPlayer());
+
+                if(message == null) {
+                    message = I18N.translate("&aThanks for your purchase, %0%", merchant.getName());
+                }else{
+                    message = ChatColor.translateAlternateColorCodes('&', message);
+                    message = message.replace("%CUSTOMER%", customer.getName());
+                    message = message.replace("%MERCHANT%", onlineMerchant.getName());
+                }
+
+                onlineMerchant.chat(message);
+                break;
+            case SYSTEM_CHAT:
+                if(message == null){
+                    message = I18N.translate("&a[%0%]: Thanks for your purchase, %1%", merchant.getName(), customer.getName());
+                }else{
+                    message = ChatColor.translateAlternateColorCodes('&', message);
+                    message = message.replace("%CUSTOMER%", customer.getName());
+                    if(merchant.getName() != null) {
+                        message = message.replace("%MERCHANT%", merchant.getName());
+                    }else{
+                        message = message.replace("%MERCHANT%", "an unknown merchant");
+                    }
+                }
+
+                Bukkit.broadcastMessage(message);
+        }
     }
 
     public static void openMerchant(Player player, OfflinePlayer store, boolean unsuccessfulFeedback, boolean isReopen){

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,7 +11,25 @@ stockLocations:
   - itemstorage # Requires item storage to be enabled, otherwise ignored.
 
 # Automatically thank a player for a purchase
-autoThanks: true
+autoThanks:
+  # Supported modes are:
+  # - player_chat: Send a message as the player in chat.
+  # -     * may break on some versions of Paper, if the message contains colour or other formatting.
+  # -     * does not work while the store player is offline.
+  # - system_chat: Send a server message.
+  # -     * works while the store player is offline.
+  # - none: Disable autoThanks.
+  mode: system_chat
+  # Choose the message to send.
+  # - Use "default" for the default message.
+  # - Or, specify your own message, with colour codes accepted (example: &a for green).
+  # Custom message replacements:
+  # - %CUSTOMER% - The player that made the purchased.
+  # - %MERCHANT% - The player that was purchased from.
+  # Default messages are these:
+  # - player_chat: "&aThanks for your purchase, %CUSTOMER%"
+  # - system_chat: "&a[%MERCHANT%]: Thanks for your purchase, %CUSTOMER%"
+  message: "default"
 
 # Selected language (see the languages folder for a list of languages (or make your own inside that folder))
 currentLanguage: en_us

--- a/src/main/resources/languages/en_us.json
+++ b/src/main/resources/languages/en_us.json
@@ -1,5 +1,5 @@
 {
-  "$$version$$": 8,
+  "$$version$$": 9,
   "&e%0% is now trading with you.": "&e%0% is now trading with you.",
   "&2Villager Store: ": "&2Villager Store: ",
   "&aThanks for your purchase, %0%": "&aThanks for your purchase, %0%",
@@ -190,5 +190,6 @@
   "&eWhen enabled, this trade will be hidden when out of stock.": "&eWhen enabled, this trade will be hidden when out of stock.",
   "&aUpdated hide on out of stock.": "&aUpdated hide on out of stock.",
   "&cBad Syntax! &f/spt hidewhenout <id> <yes|no|true|false>": "&cBad Syntax! &f/spt hidewhenout <id> <yes|no|true|false>",
-  "&f/spt hidewhenout <id> <yes|no|true|false> &e- Set hide when out of stock setting": "&f/spt hidewhenout <id> <yes|no|true|false> &e- Set hide when out of stock setting"
+  "&f/spt hidewhenout <id> <yes|no|true|false> &e- Set hide when out of stock setting": "&f/spt hidewhenout <id> <yes|no|true|false> &e- Set hide when out of stock setting",
+  "&a[%0%]: Thanks for your purchase, %1%": "&a[%0%]: Thanks for your purchase, %1%"
 }


### PR DESCRIPTION
**Test Build Download:** https://github.com/Mrcomputer1/SmileyPlayerTrader/suites/8627013975/artifacts/387387025
**Planned Update Release:** Tomorrow Night

# Reasons
* On Paper-based servers, sending messages with colour as the player results in that player being kicked.
* With offline trading and an offline merchant, thanks messages cannot be sent with player chat.

# Changes/To Do
* [x] Rework how configurations values are accessed to make things easier.
* [x] Add `system_chat` `autoThanks` option.
* [x] ~~Add a once off console message when upgrading the plugin to inform the server owner of the change to the default of `autoThanks`.~~ - Decided against this, the change is pretty minor and will be mentioned in change log anyway.

# Configuration Changes
* `autoThanks` is now a configuration section instead of a boolean (although a boolean is still accepted).
* `autoThanks.mode` has the following options `player_chat`, `system_chat` or `none`.
* `autoThanks.message` can be either "default" for the default message or a custom message.
* `autoThanks: true` will now default to `system_chat` option instead of `player_chat`.

# Translation Changes
* Added: `&a[%0%]: Thanks for your purchase, %1%`