### PR TITLE
Allowed Worlds and Regions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 16
+          java-version: 21
           distribution: adopt
       
       - name: Build Smiley Player Trader

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -36,5 +36,10 @@
       <option name="name" value="JBoss Community repository" />
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="sk89q-repo" />
+      <option name="name" value="sk89q-repo" />
+      <option name="url" value="https://maven.enginehub.org/repo/" />
+    </remote-repository>
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/releases/</url>
         </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -129,6 +133,12 @@
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.6</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.13</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
@@ -3,6 +3,7 @@ package io.github.mrcomputer1.smileyplayertrader;
 import io.github.mrcomputer1.smileyplayertrader.gui.framework.GUIManager;
 import io.github.mrcomputer1.smileyplayertrader.util.GeyserUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.I18N;
+import io.github.mrcomputer1.smileyplayertrader.util.RegionUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.item.ItemUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.database.statements.StatementHandler;
 import io.github.mrcomputer1.smileyplayertrader.util.item.stocklocations.StockLocations;
@@ -301,9 +302,15 @@ public class EventListener implements Listener {
 
         if(SmileyPlayerTrader.getInstance().getConfiguration().getAutoCombatLockEnabled()) {
             if (e.getDamager() instanceof Player) {
-                SmileyPlayerTrader.getInstance().getPlayerConfig().lockPlayer((Player) e.getDamager());
+                Player player = (Player) e.getDamager();
+                if(!RegionUtil.isAllowed(player))
+                    return;
+                SmileyPlayerTrader.getInstance().getPlayerConfig().lockPlayer(player);
             }
             if (e.getEntity() instanceof Player){
+                Player player = (Player) e.getEntity();
+                if(!RegionUtil.isAllowed(player))
+                    return;
                 SmileyPlayerTrader.getInstance().getPlayerConfig().lockPlayer((Player) e.getEntity());
             }
         }

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/EventListener.java
@@ -284,8 +284,19 @@ public class EventListener implements Listener {
 
     @EventHandler
     public void onEntityTakeDamageByEntity(EntityDamageByEntityEvent e) {
-        if(SmileyPlayerTrader.getInstance().getConfiguration().getDisabledWorlds().contains(e.getEntity().getWorld().getName())){
-            return;
+        switch (SmileyPlayerTrader.getInstance().getConfiguration().getAllowedWorldsMode()) {
+            case WHITELIST: {
+                if (!SmileyPlayerTrader.getInstance().getConfiguration().getAllowedWorldsList().contains(e.getEntity().getWorld().getName()))
+                    return;
+
+                break;
+            }
+            case BLACKLIST: {
+                if (SmileyPlayerTrader.getInstance().getConfiguration().getAllowedWorldsList().contains(e.getEntity().getWorld().getName()))
+                    return;
+
+                break;
+            }
         }
 
         if(SmileyPlayerTrader.getInstance().getConfiguration().getAutoCombatLockEnabled()) {

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/SPTConfiguration.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/SPTConfiguration.java
@@ -14,9 +14,53 @@ public class SPTConfiguration {
         this.config = config;
     }
 
-    public List<String> getDisabledWorlds(){
+    // Allowed Worlds
+    public enum EnumAllowedWorldsMode {
+        BLACKLIST("blacklist"),
+        WHITELIST("whitelist");
+
+        private static final Map<String, EnumAllowedWorldsMode> allowedWorldModes = new HashMap<>();
+
+        static {
+            for (EnumAllowedWorldsMode mode : values()) {
+                allowedWorldModes.put(mode.id.toLowerCase(), mode);
+            }
+        }
+
+        public static EnumAllowedWorldsMode getById(String id) {
+            if (id == null)
+                return BLACKLIST;
+            EnumAllowedWorldsMode mode = allowedWorldModes.get(id.toLowerCase());
+            return mode == null ? EnumAllowedWorldsMode.BLACKLIST : mode;
+        }
+
+        private final String id;
+
+        EnumAllowedWorldsMode(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    public EnumAllowedWorldsMode getAllowedWorldsMode() {
+        return EnumAllowedWorldsMode.getById(this.config.getString("allowedWorlds.mode", EnumAllowedWorldsMode.BLACKLIST.getId()));
+    }
+
+    public List<String> getAllowedWorldsList() {
+        if (this.config.contains("allowedWorlds.worlds", true))
+            return this.config.getStringList("allowedWorlds.worlds");
+
+        // Legacy config property support
         return this.config.getStringList("disabledWorlds");
     }
+
+    public boolean hasLegacyDisabledWorldsAndAllowedWorldsConfig() {
+        return this.config.contains("disabledWorlds", true) && this.config.contains("allowedWorlds.worlds", true);
+    }
+    // End Allowed Worlds
 
     public List<String> getStockLocations(){
         return this.config.getStringList("stockLocations");

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/SmileyPlayerTrader.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/SmileyPlayerTrader.java
@@ -2,6 +2,7 @@ package io.github.mrcomputer1.smileyplayertrader;
 
 import io.github.mrcomputer1.smileyplayertrader.command.CommandSmileyPlayerTrader;
 import io.github.mrcomputer1.smileyplayertrader.gui.framework.GUIManager;
+import io.github.mrcomputer1.smileyplayertrader.util.RegionUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.SPTPlaceholderExpansions;
 import io.github.mrcomputer1.smileyplayertrader.util.database.AbstractDatabase;
 import io.github.mrcomputer1.smileyplayertrader.util.database.DatabaseUtil;
@@ -133,6 +134,12 @@ public class SmileyPlayerTrader extends JavaPlugin {
         if(Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             new SPTPlaceholderExpansions().register();
         }
+    }
+
+    @Override
+    public void onLoad() {
+        // Regions
+        RegionUtil.setup();
     }
 
     @Override

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/SmileyPlayerTrader.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/SmileyPlayerTrader.java
@@ -41,6 +41,11 @@ public class SmileyPlayerTrader extends JavaPlugin {
         saveDefaultConfig();
         this.configuration = new SPTConfiguration(getConfig());
 
+        if(this.configuration.hasLegacyDisabledWorldsAndAllowedWorldsConfig())
+            getLogger().warning("The configuration file specifies both the legacy 'disabledWorlds' configuration setting " +
+                    "and the newer 'allowedWorlds' setting. The 'allowedWorlds.worlds' list will be prioritised over the " +
+                    "legacy 'disabledWorlds' setting.");
+
         // bStats
         if(!getDescription().getVersion().contains("-SNAPSHOT")) { // Disable bStats on development versions.
             this.metrics = new Metrics(this, BSTATS_PLUGIN_ID);

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/RegionUtil.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/RegionUtil.java
@@ -1,0 +1,27 @@
+package io.github.mrcomputer1.smileyplayertrader.util;
+
+import io.github.mrcomputer1.smileyplayertrader.util.impl.region.IRegionImpl;
+import io.github.mrcomputer1.smileyplayertrader.util.impl.region.NullRegionImpl;
+import io.github.mrcomputer1.smileyplayertrader.util.impl.region.WorldGuardRegionImpl;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class RegionUtil {
+
+    private static IRegionImpl impl;
+
+    public static void setup() {
+        if (Bukkit.getPluginManager().getPlugin("WorldGuard") != null) {
+            impl = new WorldGuardRegionImpl();
+        } else {
+            impl = new NullRegionImpl();
+        }
+
+        impl.registerFlag();
+    }
+
+    public static boolean isAllowed(Player player) {
+        return impl.isAllowed(player);
+    }
+
+}

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/impl/region/IRegionImpl.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/impl/region/IRegionImpl.java
@@ -1,0 +1,10 @@
+package io.github.mrcomputer1.smileyplayertrader.util.impl.region;
+
+import org.bukkit.entity.Player;
+
+public interface IRegionImpl {
+
+    boolean isAllowed(Player player);
+    void registerFlag();
+
+}

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/impl/region/NullRegionImpl.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/impl/region/NullRegionImpl.java
@@ -1,0 +1,16 @@
+package io.github.mrcomputer1.smileyplayertrader.util.impl.region;
+
+import org.bukkit.entity.Player;
+
+public class NullRegionImpl implements IRegionImpl {
+
+    @Override
+    public boolean isAllowed(Player player) {
+        return true;
+    }
+
+    @Override
+    public void registerFlag() {
+    }
+
+}

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/impl/region/WorldGuardRegionImpl.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/impl/region/WorldGuardRegionImpl.java
@@ -1,0 +1,49 @@
+package io.github.mrcomputer1.smileyplayertrader.util.impl.region;
+
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
+import org.bukkit.entity.Player;
+
+public class WorldGuardRegionImpl implements IRegionImpl {
+
+    private StateFlag flag;
+
+    @Override
+    public boolean isAllowed(Player player) {
+        LocalPlayer localPlayer  = WorldGuardPlugin.inst().wrapPlayer(player);
+
+        // Bypass
+        if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(localPlayer, localPlayer.getWorld()))
+            return true;
+
+        // Region
+        RegionQuery query = WorldGuard.getInstance().getPlatform().getRegionContainer().createQuery();
+        return query.testState(localPlayer.getLocation(), localPlayer, flag);
+    }
+
+    @Override
+    public void registerFlag() {
+        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+
+        try {
+            StateFlag flag = new StateFlag("smiley-player-trader", true);
+            registry.register(flag);
+            this.flag = flag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get("smiley-player-trader");
+            if (existing instanceof StateFlag) {
+                this.flag = (StateFlag) existing;
+            } else {
+                SmileyPlayerTrader.getInstance().getLogger().warning("Failed to register WorldGuard flag due to incompatible conflicting flag from another plugin.");
+            }
+        }
+    }
+
+}

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
@@ -108,10 +108,25 @@ public class MerchantUtil {
             return;
         }
 
-        if(SmileyPlayerTrader.getInstance().getConfiguration().getDisabledWorlds().contains(player.getWorld().getName())){
-            if(unsuccessfulFeedback)
-                player.sendMessage(I18N.translate("&cYou cannot trade in this world."));
-            return;
+        switch (SmileyPlayerTrader.getInstance().getConfiguration().getAllowedWorldsMode()) {
+            case WHITELIST: {
+                if (!SmileyPlayerTrader.getInstance().getConfiguration().getAllowedWorldsList().contains(player.getWorld().getName())){
+                    if(unsuccessfulFeedback)
+                        player.sendMessage(I18N.translate("&cYou cannot trade in this world."));
+                    return;
+                }
+
+                break;
+            }
+            case BLACKLIST: {
+                if (SmileyPlayerTrader.getInstance().getConfiguration().getAllowedWorldsList().contains(player.getWorld().getName())){
+                    if(unsuccessfulFeedback)
+                        player.sendMessage(I18N.translate("&cYou cannot trade in this world."));
+                    return;
+                }
+
+                break;
+            }
         }
 
         if(player.getUniqueId().equals(store.getUniqueId()) && !SmileyPlayerTrader.getInstance().getConfiguration().getDebugSelfTrading()){

--- a/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
+++ b/src/main/java/io/github/mrcomputer1/smileyplayertrader/util/merchant/MerchantUtil.java
@@ -3,6 +3,7 @@ package io.github.mrcomputer1.smileyplayertrader.util.merchant;
 import io.github.mrcomputer1.smileyplayertrader.SPTConfiguration;
 import io.github.mrcomputer1.smileyplayertrader.SmileyPlayerTrader;
 import io.github.mrcomputer1.smileyplayertrader.util.I18N;
+import io.github.mrcomputer1.smileyplayertrader.util.RegionUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.VaultUtil;
 import io.github.mrcomputer1.smileyplayertrader.util.database.statements.StatementHandler;
 import io.github.mrcomputer1.smileyplayertrader.util.item.ItemUtil;
@@ -127,6 +128,12 @@ public class MerchantUtil {
 
                 break;
             }
+        }
+
+        if (!RegionUtil.isAllowed(player)) {
+            if (unsuccessfulFeedback)
+                player.sendMessage(I18N.translate("&cYou cannot trade here."));
+            return;
         }
 
         if(player.getUniqueId().equals(store.getUniqueId()) && !SmileyPlayerTrader.getInstance().getConfiguration().getDebugSelfTrading()){

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,8 +1,12 @@
 # Smiley Player Trader Configuration
 # Configuration Documentation: https://github.com/Mrcomputer1/SmileyPlayerTrader/wiki/Configuration
 
-# A list of worlds where you cannot trade with players.
-disabledWorlds: []
+# Configures worlds that players can or can't trade in.
+allowedWorlds:
+  # Either blacklist (players must not be in this world to trade) or whitelist (players must be in this to trade).
+  mode: blacklist
+  # List of worlds.
+  worlds: []
 
 # A list of sources for products
 stockLocations:

--- a/src/main/resources/languages/en_us.json
+++ b/src/main/resources/languages/en_us.json
@@ -1,5 +1,5 @@
 {
-  "$$version$$": 15,
+  "$$version$$": 16,
   "$$credit$$": "",
   "&e%0% is now trading with you.": "&e%0% is now trading with you.",
   "&2Villager Store: ": "&2Villager Store: ",
@@ -244,5 +244,6 @@
   "&cWhoops! You are not authorised to do that.": "&cWhoops! You are not authorised to do that.",
   "&aToggled unlimited supply.": "&aToggled unlimited supply.",
   "&e&lUnlimited Supply Enabled": "&e&lUnlimited Supply Enabled",
-  "&a%0% is now selling %1%.": "&a%0% is now selling %1%."
+  "&a%0% is now selling %1%.": "&a%0% is now selling %1%.",
+  "&cYou cannot trade here.": "&cYou cannot trade here."
 }

--- a/src/main/resources/languages/pl_pl.json
+++ b/src/main/resources/languages/pl_pl.json
@@ -1,5 +1,5 @@
 {
-  "$$version$$": 14,
+  "$$version$$": 15,
   "$$credit$$": "Polskie tłumaczenie wykonane przez gvvda21",
   "&e%0% is now trading with you.": "&e%0% przegląda twój sklep.",
   "&2Villager Store: ": "&2Sklep osadnika: ",
@@ -244,5 +244,6 @@
   "&cWhoops! You are not authorised to do that.": "&cUps! Nie masz uprawnien żeby to zrobić.",
   "&aToggled unlimited supply.": "&aWłączono nielimitowane zaopatrzenie.",
   "&e&lUnlimited Supply Enabled": "&e&lNielimitowane zaopatrzenie produktu włączone!",
-  "&a%0% is now selling %1%.": "&a%0% is now selling %1%."
+  "&a%0% is now selling %1%.": "&a%0% is now selling %1%.",
+  "&cYou cannot trade here.": "&cYou cannot trade here."
 }

--- a/src/main/resources/languages/ru_ru.json
+++ b/src/main/resources/languages/ru_ru.json
@@ -1,5 +1,5 @@
 {
-  "$$version$$": 18,
+  "$$version$$": 19,
   "$$credit$$": "",
   "&e%0% is now trading with you.": "&e%0% сейчас с тобой трейдится.",
   "&2Villager Store: ": "&2Магазин Жителей: ",
@@ -244,5 +244,6 @@
   "&cWhoops! You are not authorised to do that.": "&cУпс! У вас не достаточно прав для этого.",
   "&aToggled unlimited supply.": "&aПереключён бесконечный запас.",
   "&e&lUnlimited Supply Enabled": "&e&lБесконечный запас включён",
-  "&a%0% is now selling %1%.": "&aУ игрока %0% появился в продаже товар %1%."
+  "&a%0% is now selling %1%.": "&aУ игрока %0% появился в продаже товар %1%.",
+  "&cYou cannot trade here.": "&cYou cannot trade here."
 }

--- a/src/main/resources/languages/vi_vn.json
+++ b/src/main/resources/languages/vi_vn.json
@@ -1,5 +1,5 @@
 {
-  "$$version$$": 15,
+  "$$version$$": 16,
   "$$credit$$": "Bản dịch tiếng Việt được dịch bởi CoPeBanSIMP",
   "&e%0% is now trading with you.": "&e%0% hiện tại đang mở shop của bạn.",
   "&2Villager Store: ": "&1Người bán: &4&l",
@@ -244,5 +244,6 @@
   "&cWhoops! You are not authorised to do that.": "&cWhoops! Bạn không có quyền để dùng chức năng này.",
   "&aToggled unlimited supply.": "&aNguồn vật phẩm không giới hạn đã được cập nhập cho vật phẩm.",
   "&e&lUnlimited Supply Enabled": "&d&oNguồn vật phẩm không giới hạn đã được kích hoạt",
-  "&a%0% is now selling %1%.": "&a%0% is now selling %1%."
+  "&a%0% is now selling %1%.": "&a%0% is now selling %1%.",
+  "&cYou cannot trade here.": "&cYou cannot trade here."
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,7 @@ softdepend:
   - Geyser-Spigot # for better experience on bedrock
   - floodgate # for better experience on bedrock
   - PlaceholderAPI # to create placeholder expansions
+  - WorldGuard # for region flag
 commands:
   smileyplayertrader:
     description: "Smiley Player Trader Command"


### PR DESCRIPTION
Closes #76

- [x] Replace `disabledWorlds` with `allowedWorlds` and modes for whitelist and blacklist.
- [x] Add a WorldGuard flag (`smiley-player-trader`).

# Configuration Changes
* Deprecated `disabledWorlds` option.
* Added `allowedWorlds` option with `mode` and `worlds` sub-option.

# Translation Changes
* Added `&cYou cannot trade here.` translation.